### PR TITLE
Change admin account type and Display account type on userlist page and in post headers

### DIFF
--- a/src/posts/user.js
+++ b/src/posts/user.js
@@ -104,7 +104,7 @@ module.exports = function (Posts) {
             'uid', 'username', 'fullname', 'userslug',
             'reputation', 'postcount', 'topiccount', 'picture',
             'signature', 'banned', 'banned:expire', 'status',
-            'lastonline', 'groupTitle', 'mutedUntil',
+            'lastonline', 'groupTitle', 'mutedUntil', 'accounttype',
         ];
         const result = await plugins.hooks.fire('filter:posts.addUserFields', {
             fields: fields,

--- a/src/user/create.js
+++ b/src/user/create.js
@@ -1,5 +1,7 @@
 'use strict';
 
+const assert = require('assert');
+
 const zxcvbn = require('zxcvbn');
 const winston = require('winston');
 
@@ -49,12 +51,15 @@ module.exports = function (User) {
         let userData = {
             username: data.username,
             userslug: data.userslug,
-            accounttype: data.accounttype || 'student',
+            accounttype: data.accounttype || 'administrator',
             email: data.email || '',
             joindate: timestamp,
             lastonline: timestamp,
             status: 'online',
         };
+
+        assert(typeof userData.accounttype === 'string');
+
         ['picture', 'fullname', 'location', 'birthday'].forEach((field) => {
             if (data[field]) {
                 userData[field] = data[field];

--- a/themes/nodebb-theme-persona/templates/partials/topic/post.tpl
+++ b/themes/nodebb-theme-persona/templates/partials/topic/post.tpl
@@ -10,6 +10,7 @@
         <strong>
             <a href="<!-- IF posts.user.userslug -->{config.relative_path}/user/{posts.user.userslug}<!-- ELSE -->#<!-- ENDIF posts.user.userslug -->" itemprop="author" data-username="{posts.user.username}" data-uid="{posts.user.uid}">{posts.user.displayname}</a>
         </strong>
+        <span class="accounttype">({posts.user.accounttype})</span>
 
         <!-- IMPORT partials/topic/badge.tpl -->
 

--- a/themes/nodebb-theme-persona/templates/partials/users_list.tpl
+++ b/themes/nodebb-theme-persona/templates/partials/users_list.tpl
@@ -6,6 +6,8 @@
         <span>
             <i component="user/status" class="fa fa-circle status {users.status}" title="[[global:{users.status}]]"></i>
             <a href="{config.relative_path}/user/{users.userslug}">{users.username}</a>
+            <br>
+            <small class="accounttype">({users.accounttype})</small>
         </span>
         <br/>
 


### PR DESCRIPTION
Resolves #18 - Display account type on userlist page
- retrieves 'accounttype' value from userData and displays it under username within partials/users_list.tpl

Resolves #17 - Display account type in post headers
- includes 'accounttype' field in output of getUserData function in src/posts/user.js
- retrieves 'accounttype' value from userData and displays it next to username within partials/topic/post.tpl

Resolves #20 - Change default admin account type to 'administrator'
- changes default accounttype value in src/user/create.js from 'student' to 'administrator'