### PR TITLE
Fixed error when starting server after TS translation

### DIFF
--- a/src/controllers/lists.js
+++ b/src/controllers/lists.js
@@ -1,7 +1,12 @@
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
+exports.test = exports.get = void 0;
 function get(req, res) {
     const listsData = {};
     res.render('lists', listsData);
 }
-exports.default = get;
+exports.get = get;
+function test() {
+    return {};
+}
+exports.test = test;

--- a/src/controllers/lists.ts
+++ b/src/controllers/lists.ts
@@ -1,6 +1,10 @@
 import { Request, Response } from 'express';
 
-export default function get(req : Request, res : Response) {
+export function get(req : Request, res : Response) {
     const listsData = {};
     res.render('lists', listsData);
+}
+
+export function test() {
+    return {};
 }


### PR DESCRIPTION
The server was not running properly after the JS to TS translation of src/controllers/lists. This has been fixed by removing the use of the default keyword. This time, the changes have been tested by running the server locally.