### PR TITLE
Install Bearer

### DIFF
--- a/bearer.yml
+++ b/bearer.yml
@@ -1,0 +1,28 @@
+disable-version-check: false
+log-level: info
+report:
+    fail-on-severity: critical,high,medium,low
+    format: ""
+    no-color: false
+    output: ""
+    report: security
+    severity: critical,high,medium,low,warning
+rule:
+    disable-default-rules: false
+    only-rule: []
+    skip-rule: []
+scan:
+    context: ""
+    data_subject_mapping: ""
+    disable-domain-resolution: true
+    domain-resolution-timeout: 3s
+    exit-code: -1
+    external-rule-dir: []
+    force: false
+    hide_progress_bar: false
+    internal-domains: []
+    parallel: 0
+    quiet: false
+    scanner:
+        - sast
+    skip-path: []


### PR DESCRIPTION
Installed and ran Bearer on our codebase. Bearer is a static security testing tool focusing on security and privacy risks. For this PR I only installed and used their command line interface. For the future, the CI/CD features look feasible to implement.

To install locally run:
```
sudo apt-get update && sudo apt-get install ca-certificates -y && sudo update-ca-certificates
sudo apt-get install apt-transport-https
echo "deb [trusted=yes] https://apt.fury.io/bearer/ /" | sudo tee -a /etc/apt/sources.list.d/fury.list
sudo apt-get update
sudo apt-get install bearer
```
(installation guide [here](https://docs.bearer.com/reference/installation/))

Results from `bearer scan src`:
![image](https://github.com/CMU-313/spring24-nodebb-ecats/assets/29717543/f9c4b091-64d5-4949-ad2d-2de3cfc54390)
